### PR TITLE
Fix window size issue on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <title>Flip Activity</title>
-  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width"/>
+  <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, viewport-fit=cover"/>
   <link rel="stylesheet" media="not screen and (device-width: 1200px) and (device-height: 900px)"
   	href="lib/sugar-web/graphics/css/sugar-96dpi.css">
   <link rel="stylesheet" media="screen and (device-width: 1200px) and (device-height: 900px)"


### PR DESCRIPTION
I've integrated your activity in Sugarizer here https://github.com/llaske/sugarizer/commit/7352fddffb8449596e5b7876c24fcb7bc02eddd8 
I've just fixed a small issue on iOS due to a recent change in iOS11.
BTW I suggest few enhancements to your activity:
- The Help icon is not a good idea, it's usually used for a tutorial on activity though here it's an help of the IA. May be you could replace it by the Robot from your Reflection activity
- We win only if all pawns are in the foreground color. I think it could be nice also to win if all pawns are in the background color. In both case everything has the same color
- It could be nice to display the count number to challenge the user.
